### PR TITLE
feat: add invertHex to Gluegun toolbox

### DIFF
--- a/src/commands/bg-colors.ts
+++ b/src/commands/bg-colors.ts
@@ -1,22 +1,12 @@
 import chalk from 'chalk'
 import convert from 'color-convert'
-import { GluegunToolbox } from 'gluegun'
+import { customGluegunToolbox } from '../types'
 import puppeteer from 'puppeteer'
-
-/**
- * Invert a hexadecimal color.
- * @param {string} hex - the hexadecimal value to be inverted.
- */
-const invertHex = (hex: string) =>
-  (Number(`0x1${hex.substring(1)}`) ^ 0xffffff)
-    .toString(16)
-    .substring(1)
-    .toUpperCase()
 
 module.exports = {
   name: 'bg-colors',
   alias: 'bgc',
-  run: async (toolbox: GluegunToolbox) => {
+  run: async (toolbox: customGluegunToolbox) => {
     // no url provided
     if (!toolbox.parameters.first) {
       toolbox.print.info('pass page URL!')
@@ -71,7 +61,9 @@ module.exports = {
       ${styles.background
         .map(
           (background) =>
-            `${chalk.bgHex(background).hex(invertHex(background))(background)}`
+            `${chalk.bgHex(background).hex(toolbox.invertHex(background))(
+              background
+            )}`
         )
         .join(`    `)}
       `

--- a/src/extensions/cli-extension.ts
+++ b/src/extensions/cli-extension.ts
@@ -1,11 +1,17 @@
-import { GluegunToolbox } from 'gluegun'
-
+import { customGluegunToolbox } from '../types'
 // add your CLI-specific functionality here, which will then be accessible
 // to your commands
-module.exports = (toolbox: GluegunToolbox) => {
-  toolbox.foo = () => {
-    toolbox.print.info('called foo extension')
-  }
+module.exports = (toolbox: customGluegunToolbox) => {
+  /**
+   * Invert a hexadecimal color.
+   * @param {string} hex - the hexadecimal value to be inverted.
+   * @returns {string} - result of inversion.
+   */
+  toolbox.invertHex = (hex: string) =>
+    (Number(`0x1${hex.substring(1)}`) ^ 0xffffff)
+      .toString(16)
+      .substring(1)
+      .toUpperCase()
 
   // enable this if you want to read configuration in from
   // the current folder's package.json (in a "get-design" property),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,1 +1,5 @@
-// export types
+import { GluegunToolbox } from 'gluegun'
+
+export interface customGluegunToolbox extends GluegunToolbox {
+  invertHex: (hex: string) => string
+}


### PR DESCRIPTION
Extend Gluegun toolbox w/ invertHex for reusability across commands.